### PR TITLE
Fix: Deep Transform object to escape `[` and `]`

### DIFF
--- a/logstash-codec-gzip_lines.gemspec
+++ b/logstash-codec-gzip_lines.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-gzip_lines'
-  s.version         = '3.0.6'
+  s.version         = '3.0.7'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads `gzip` encoded content"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fix: Deep Transform object to escape `[` and `]`
Bump version to 3.0.7
